### PR TITLE
Support Diagnostic

### DIFF
--- a/src/CSRedisCore/CSRedisCore.csproj
+++ b/src/CSRedisCore/CSRedisCore.csproj
@@ -27,6 +27,16 @@
 		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+	  <PackageReference Include="System.Diagnostics.DiagnosticSource">
+	    <Version>4.7.0</Version>
+	  </PackageReference>
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+	  <PackageReference Include="System.Diagnostics.DiagnosticSource">
+	    <Version>4.7.0</Version>
+	  </PackageReference>
+	</ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net40'">
     <DefineConstants>net40</DefineConstants>
   </PropertyGroup>

--- a/src/CSRedisCore/Internal/CSRedisDiagnosticListenerExtensions.cs
+++ b/src/CSRedisCore/Internal/CSRedisDiagnosticListenerExtensions.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace CSRedis.Internal
+{
+#if net40
+#else
+    internal static class CSRedisDiagnosticListenerExtensions
+    {
+        public const string DiagnosticListenerName = "CSRedisDiagnosticListener";
+
+        public const string CSRedisPrefix = "CSRedis.";
+
+        public const string CSRedisBeforeCall = CSRedisPrefix + nameof(WriteCallBefore);
+        public const string CSRedisAfterCall = CSRedisPrefix + nameof(WriteCallAfter);
+        public const string CSRedisErrorCall = CSRedisPrefix + nameof(WriteCallError);
+
+
+        public static Guid WriteCallBefore(this DiagnosticListener @this, CallEventData eventData)
+        {
+            if (@this.IsEnabled(CSRedisBeforeCall))
+            {
+                Guid operationId = Guid.NewGuid();
+
+                @this.Write(CSRedisBeforeCall, new
+                {
+                    OperationId = operationId,
+                    EventData = eventData
+                });
+
+                return operationId;
+            }
+
+            return Guid.Empty;
+        }
+
+        public static Guid WriteCallAfter(this DiagnosticListener @this, Guid operationId, CallEventData eventData)
+        {
+            if (@this.IsEnabled(CSRedisAfterCall))
+            {
+                @this.Write(CSRedisAfterCall, new
+                {
+                    OperationId = operationId,
+                    EventData = eventData
+                });
+
+                return operationId;
+            }
+
+            return Guid.Empty;
+        }
+
+        public static void WriteCallError(this DiagnosticListener @this, Guid operationId, CallEventData eventData, Exception ex)
+        {
+            if (@this.IsEnabled(CSRedisErrorCall))
+            {
+                @this.Write(CSRedisErrorCall, new
+                {
+                    OperationId = operationId,
+                    EventData = eventData,
+                    Exception = ex
+                });
+            }
+        }
+    }
+
+    public class EventData
+    {
+        public EventData(string operation)
+        {           
+            Operation = operation;
+        }
+
+        public string Operation { get; }
+    }
+
+    public class CallEventData : EventData
+    {
+        public CallEventData(string operation) : base(operation)
+        {
+        }
+
+        public string Key { get; set; }
+    }
+#endif
+}

--- a/src/CSRedisCore/Internal/Diagnostics/CSRedisDiagnosticListenerExtensions.cs
+++ b/src/CSRedisCore/Internal/Diagnostics/CSRedisDiagnosticListenerExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
-namespace CSRedis.Internal
+namespace CSRedis.Internal.Diagnostics
 {
 #if net40
 #else
@@ -24,11 +24,7 @@ namespace CSRedis.Internal
             {
                 Guid operationId = Guid.NewGuid();
 
-                @this.Write(CSRedisBeforeCall, new
-                {
-                    OperationId = operationId,
-                    EventData = eventData
-                });
+                @this.Write(CSRedisBeforeCall, eventData);
 
                 return operationId;
             }
@@ -64,25 +60,6 @@ namespace CSRedis.Internal
                 });
             }
         }
-    }
-
-    public class EventData
-    {
-        public EventData(string operation)
-        {           
-            Operation = operation;
-        }
-
-        public string Operation { get; }
-    }
-
-    public class CallEventData : EventData
-    {
-        public CallEventData(string operation) : base(operation)
-        {
-        }
-
-        public string Key { get; set; }
-    }
+    } 
 #endif
 }

--- a/src/CSRedisCore/Internal/Diagnostics/EventData.cs
+++ b/src/CSRedisCore/Internal/Diagnostics/EventData.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace CSRedis.Internal.Diagnostics
+{
+#if net40
+#else
+    public class EventData
+    {
+        public EventData(string operation)
+        {           
+            Operation = operation;
+        }
+
+        public string Operation { get; }
+    }
+
+    public class CallEventData : EventData
+    {
+        public CallEventData(string operation, string key) : base(operation)
+        {
+            Key = key;
+        }
+
+        public string Key { get; private set; }
+    }
+#endif
+}

--- a/test/CSRedisCore.Tests/CSRedisDiagnosticsTest.cs
+++ b/test/CSRedisCore.Tests/CSRedisDiagnosticsTest.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CSRedisCore.Tests
+{
+    public class CSRedisDiagnosticsTest : TestBase
+    {
+        [Fact]
+        public async Task WriteCallTest()
+        {
+            var statsLogged = false;
+
+            FakeDiagnosticListenerObserver diagnosticListenerObserver = new FakeDiagnosticListenerObserver(kvp =>
+            {
+                if (kvp.Key.Equals("CSRedis.WriteCallBefore"))
+                {
+                    Assert.NotNull(kvp.Value);
+
+                    statsLogged = true;
+                }
+                else if (kvp.Key.Equals("CSRedis.WriteCallAfter"))
+                {
+                    Assert.NotNull(kvp.Value);
+
+                    statsLogged = true;
+                }
+            });
+
+            diagnosticListenerObserver.Enable();
+            using (DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver))
+            {
+                var key = "CSRedisDiagnostics";
+
+                //await rds.SetAsync(key, base.String);
+                await rds.AppendAsync(key, base.Null);
+
+                Assert.True(statsLogged);
+
+                diagnosticListenerObserver.Disable();
+            }
+        }
+    }
+
+    public sealed class FakeDiagnosticListenerObserver : IObserver<DiagnosticListener>
+    {
+        private class FakeDiagnosticSourceWriteObserver : IObserver<KeyValuePair<string, object>>
+        {
+            private readonly Action<KeyValuePair<string, object>> _writeCallback;
+
+            public FakeDiagnosticSourceWriteObserver(Action<KeyValuePair<string, object>> writeCallback)
+            {
+                _writeCallback = writeCallback;
+            }
+
+            public void OnCompleted()
+            {
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+            public void OnNext(KeyValuePair<string, object> value)
+            {
+                _writeCallback(value);
+            }
+        }
+
+        private readonly Action<KeyValuePair<string, object>> _writeCallback;
+        private bool _writeObserverEnabled;
+
+        public FakeDiagnosticListenerObserver(Action<KeyValuePair<string, object>> writeCallback)
+        {
+            _writeCallback = writeCallback;
+        }
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(DiagnosticListener value)
+        {
+            if (value.Name.Equals("CSRedisDiagnosticListener"))
+            {
+                value.Subscribe(new FakeDiagnosticSourceWriteObserver(_writeCallback), IsEnabled);
+            }
+        }
+
+        public void Enable()
+        {
+            _writeObserverEnabled = true;
+        }
+        public void Disable()
+        {
+            _writeObserverEnabled = false;
+        }
+        private bool IsEnabled(string s)
+        {
+            return _writeObserverEnabled;
+        }
+    }
+}


### PR DESCRIPTION
Following #186 , adding support for `Diagnostics` feature.

The PR contains three events to record for diagnostics.

1. Before on calling a Redis command
2. After on calling a Redis command
3. Error on calling a Redis command

Only record the command and key for each operation, because I am not sure if there should record other information here.
