### PR TITLE
use correct framework

### DIFF
--- a/src/Microsoft.Extensions.Caching.CSRedis/Microsoft.Extensions.Caching.CSRedis.csproj
+++ b/src/Microsoft.Extensions.Caching.CSRedis/Microsoft.Extensions.Caching.CSRedis.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net80;net70;net60;net50;netcoreapp31;netcoreapp21</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
 		<AssemblyName>Caching.CSRedis</AssemblyName>
 		<PackageId>Caching.CSRedis</PackageId>
 		<RootNamespace>Caching.CSRedis</RootNamespace>
@@ -20,24 +20,23 @@
 		<WarningLevel>3</WarningLevel>
 		<NoWarn>1701;1702;1591</NoWarn>
 	</PropertyGroup>
-	
-	
-	<ItemGroup Condition="'$(TargetFramework)' == 'net80' or '$(TargetFramework)' == 'netstandard2.0'">
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net70'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net60'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net50'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp31'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.10" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp21'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.23" />
 	</ItemGroup>
 


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)