### PR TITLE
fix: XINFO GROUPS的entries-read和lag错误使用BulkString读取

### DIFF
--- a/src/CSRedisCore/Internal/Commands/RedisStreamCommand.cs
+++ b/src/CSRedisCore/Internal/Commands/RedisStreamCommand.cs
@@ -257,6 +257,12 @@ namespace CSRedis.Internal.Commands
                         case "last-delivered-id":
                             ret[a].lastDeliveredId = reader.ReadBulkString();
                             break;
+			case "entries-read":
+                            reader.ReadInt();
+                            break;
+                        case "lag":
+                            reader.ReadInt();
+                            break;
                         default:
                             reader.ReadBulkString();
                             break;


### PR DESCRIPTION
#526 #520 